### PR TITLE
Log console.group and console.groupCollapsed

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -356,6 +356,14 @@
       enhance(console, "error", function() {
         trackLog("error", arguments);
       });
+
+      enhance(console, "group", function() {
+        trackLog("group", arguments);
+      });
+
+      enhance(console, "groupCollapsed", function() {
+        trackLog("groupCollapsed", arguments);
+      });
     };
 
     self.disableAutoBreadcrumbsConsole = function() {


### PR DESCRIPTION
since it adds some context to the console.logs etc that happen in that group